### PR TITLE
Removed unneeded progress bars and adjusted form validation

### DIFF
--- a/src/components/adminaddresses/CreateUpdateForm.tsx
+++ b/src/components/adminaddresses/CreateUpdateForm.tsx
@@ -62,9 +62,11 @@ function CreateUpdateForm({address}: CreateUpdateFormProps) {
             values,
             errors,
             touched,
+            dirty,
             handleChange,
             handleBlur,
             handleSubmit,
+            isValid,
             isSubmitting,
             setFieldValue,
             resetForm
@@ -75,15 +77,20 @@ function CreateUpdateForm({address}: CreateUpdateFormProps) {
                 <InputControl name="CompanyName" label="Company Name" />
                 <InputControl name="FirstName" label="First Name" />
                 <InputControl name="LastName" label="Last Name" />
-                <InputControl name="Street1" label="Street 1" />
+                <InputControl name="Street1" label="Street 1" isRequired />
                 <InputControl name="Street2" label="Street 2" />
-                <InputControl name="City" label="City" />
-                <InputControl name="State" label="State" />
-                <InputControl name="Zip" label="Zip" />
-                <InputControl name="Country" label="Country" />
+                <InputControl name="City" label="City" isRequired />
+                <InputControl name="State" label="State" isRequired />
+                <InputControl name="Zip" label="Zip" isRequired />
+                <InputControl name="Country" label="Country" isRequired />
                 <InputControl name="Phone" label="Phone" />
                 <ButtonGroup>
-                  <Button variant="primaryButton" type="submit" isLoading={isSubmitting}>
+                  <Button
+                    variant="primaryButton"
+                    type="submit"
+                    isLoading={isSubmitting}
+                    isDisabled={!isValid || !dirty}
+                  >
                     Save
                   </Button>
                   <Button

--- a/src/components/adminusers/CreateUpdateForm.tsx
+++ b/src/components/adminusers/CreateUpdateForm.tsx
@@ -142,19 +142,21 @@ function CreateUpdateForm({user, assignedPermissions}: CreateUpdateFormProps) {
             values,
             errors,
             touched,
+            dirty,
             handleChange,
             handleBlur,
             handleSubmit,
+            isValid,
             isSubmitting,
             setFieldValue,
             resetForm
           }) => (
             <Box as="form" onSubmit={handleSubmit as any}>
               <Stack spacing={5}>
-                <InputControl name="Username" label="Username" />
-                <InputControl name="FirstName" label="First name" />
-                <InputControl name="LastName" label="Last name" />
-                <InputControl name="Email" label="Email" />
+                <InputControl name="Username" label="Username" isRequired />
+                <InputControl name="FirstName" label="First name" isRequired />
+                <InputControl name="LastName" label="Last name" isRequired />
+                <InputControl name="Email" label="Email" isRequired />
                 <InputControl name="Phone" label="Phone" />
                 <SwitchControl name="Active" label="Active" marginBottom={5} />
                 <PermissionsTable
@@ -162,7 +164,12 @@ function CreateUpdateForm({user, assignedPermissions}: CreateUpdateFormProps) {
                   assignedPermissions={assignedPermissions || []}
                 />
                 <ButtonGroup>
-                  <Button variant="primaryButton" type="submit" isLoading={isSubmitting}>
+                  <Button
+                    variant="primaryButton"
+                    type="submit"
+                    isLoading={isSubmitting}
+                    isDisabled={!isValid || !dirty}
+                  >
                     Save
                   </Button>
                   <Button

--- a/src/components/buyers/CreateUpdateForm.tsx
+++ b/src/components/buyers/CreateUpdateForm.tsx
@@ -1,6 +1,6 @@
 import * as Yup from "yup"
 import {Box, Button, ButtonGroup, Flex, Stack} from "@chakra-ui/react"
-import {InputControl, NumberInputControl, PercentComplete, SelectControl, SwitchControl} from "components/formik"
+import {InputControl, NumberInputControl, SelectControl, SwitchControl} from "components/formik"
 import {Buyer, Buyers, Catalog, Catalogs} from "ordercloud-javascript-sdk"
 import Card from "../card/Card"
 import {Formik} from "formik"
@@ -64,16 +64,18 @@ function CreateUpdateForm({buyer}: CreateUpdateFormProps) {
             values,
             errors,
             touched,
+            dirty,
             handleChange,
             handleBlur,
             handleSubmit,
+            isValid,
             isSubmitting,
             setFieldValue,
             resetForm
           }) => (
             <Box as="form" onSubmit={handleSubmit as any}>
               <Stack spacing={5}>
-                <InputControl name="Name" label="Buyer Name" />
+                <InputControl name="Name" label="Buyer Name" isRequired />
                 <SwitchControl name="Active" label="Active" />
                 <SelectControl
                   name="DefaultCatalogID"
@@ -89,9 +91,14 @@ function CreateUpdateForm({buyer}: CreateUpdateFormProps) {
                 <NumberInputControl name="xp_MarkupPercent" label="Markup percent" />
                 <InputControl name="xp_URL" label="Url" />
 
-                {isCreating ? <PercentComplete /> : <InputControl name="DateCreated" label="Date created" isReadOnly />}
+                {!isCreating && <InputControl name="DateCreated" label="Date created" isReadOnly />}
                 <ButtonGroup>
-                  <Button variant="primaryButton" type="submit" isLoading={isSubmitting}>
+                  <Button
+                    variant="primaryButton"
+                    type="submit"
+                    isLoading={isSubmitting}
+                    isDisabled={!isValid || !dirty}
+                  >
                     Save
                   </Button>
                   <Button

--- a/src/components/catalogs/CreateUpdateForm.tsx
+++ b/src/components/catalogs/CreateUpdateForm.tsx
@@ -49,20 +49,27 @@ function CreateUpdateForm({catalog}: CreateUpdateFormProps) {
             values,
             errors,
             touched,
+            dirty,
             handleChange,
             handleBlur,
             handleSubmit,
+            isValid,
             isSubmitting,
             setFieldValue,
             resetForm
           }) => (
             <Box as="form" onSubmit={handleSubmit as any}>
               <Stack spacing={5}>
-                <InputControl name="Name" label="Catalog Name" />
+                <InputControl name="Name" label="Catalog Name" isRequired />
                 <TextareaControl name="Description" label="Description" />
                 <SwitchControl name="Active" label="Active" />
                 <ButtonGroup>
-                  <Button variant="primaryButton" type="submit" isLoading={isSubmitting}>
+                  <Button
+                    variant="primaryButton"
+                    type="submit"
+                    isLoading={isSubmitting}
+                    isDisabled={!isValid || !dirty}
+                  >
                     Save
                   </Button>
                   <Button

--- a/src/components/categories/CreateUpdateForm.tsx
+++ b/src/components/categories/CreateUpdateForm.tsx
@@ -96,22 +96,30 @@ function CreateUpdateForm({category, headerComponent, parentId, onSuccess}: Crea
             values,
             errors,
             touched,
+            dirty,
             handleChange,
             handleBlur,
             handleSubmit,
+            isValid,
             isSubmitting,
             setFieldValue,
             resetForm
           }) => (
             <Box as="form" onSubmit={handleSubmit as any}>
               <Stack spacing={5}>
-                <InputControl name="Name" label="Category Name" />
+                <InputControl name="Name" label="Category Name" isRequired />
                 <TextareaControl name="Description" label="Description" />
                 <SwitchControl name="Active" label="Active" colorScheme="teal" size="lg" />
                 <ButtonGroup>
                   <HStack justifyContent="space-between" w="100%" mb={5}>
                     <Box>
-                      <Button variant="primaryButton" type="submit" isLoading={isSubmitting} mr="15px">
+                      <Button
+                        variant="primaryButton"
+                        type="submit"
+                        isLoading={isSubmitting}
+                        mr="15px"
+                        isDisabled={!isValid || !dirty}
+                      >
                         Save
                       </Button>
                       <Button

--- a/src/components/productfacets/CreateUpdateForm.tsx
+++ b/src/components/productfacets/CreateUpdateForm.tsx
@@ -114,16 +114,18 @@ function CreateUpdateForm({productfacet}: CreateUpdateFormProps) {
             values,
             errors,
             touched,
+            dirty,
             handleChange,
             handleBlur,
             handleSubmit,
+            isValid,
             isSubmitting,
             setFieldValue,
             resetForm
           }) => (
             <Box as="form" onSubmit={handleSubmit as any}>
               <Stack spacing={5}>
-                <InputControl name="Name" label="Product Facet Name" />
+                <InputControl name="Name" label="Product Facet Name" isRequired />
                 <FormLabel>
                   Facet Options :<Text fontSize="sm">Create options for this facet group?</Text>
                 </FormLabel>
@@ -197,7 +199,13 @@ function CreateUpdateForm({productfacet}: CreateUpdateFormProps) {
                 <ButtonGroup>
                   <HStack justifyContent="space-between" w="100%" mb={5}>
                     <Box>
-                      <Button variant="primaryButton" type="submit" isLoading={isSubmitting} mr="15px">
+                      <Button
+                        variant="primaryButton"
+                        type="submit"
+                        isLoading={isSubmitting}
+                        mr="15px"
+                        isDisabled={!isValid || !dirty}
+                      >
                         Save
                       </Button>
                       <Button onClick={reset} type="reset" variant="secondaryButton" isLoading={isSubmitting} mr="15px">

--- a/src/components/products/ProductSearch.tsx
+++ b/src/components/products/ProductSearch.tsx
@@ -129,6 +129,7 @@ export default function ProductSearch({query}: ProductSearchProps) {
   const [isAdding, setIsAdding] = useState(false)
   const [isMassEditing, setIsMassEditing] = useState(false)
   const [selectedProductIds, setSelectedProductIds] = useState<string[]>([])
+  const [isFormValid, setIsFormValid] = useState(false)
   const [formValues, setFormValues] = useState({
     id: "",
     name: "",
@@ -180,7 +181,11 @@ export default function ProductSearch({query}: ProductSearchProps) {
   }
 
   const handleInputChange = (fieldKey: string) => (e: ChangeEvent<HTMLInputElement>) => {
-    setFormValues((v) => ({...v, [fieldKey]: e.target.value}))
+    setFormValues((v) => {
+      const updatedValues = {...v, [fieldKey]: e.target.value}
+      setIsFormValid(updatedValues.id !== "" && updatedValues.name !== "")
+      return updatedValues
+    })
   }
 
   const handleCheckboxChange = (fieldKey: string) => (e: ChangeEvent<HTMLInputElement>) => {
@@ -580,8 +585,8 @@ export default function ProductSearch({query}: ProductSearchProps) {
               <ModalHeader>Add a new Product</ModalHeader>
               <ModalCloseButton />
               <ModalBody pb={6}>
-                <FormControl>
-                  <FormLabel>ID*</FormLabel>
+                <FormControl isRequired>
+                  <FormLabel>ID</FormLabel>
                   <Input
                     autoComplete="off"
                     placeholder="123456"
@@ -590,8 +595,8 @@ export default function ProductSearch({query}: ProductSearchProps) {
                   />
                 </FormControl>
 
-                <FormControl mt={4}>
-                  <FormLabel>Name*</FormLabel>
+                <FormControl mt={4} isRequired>
+                  <FormLabel>Name</FormLabel>
                   <Input
                     autoComplete="off"
                     placeholder="New Product"
@@ -621,7 +626,13 @@ export default function ProductSearch({query}: ProductSearchProps) {
                   <Button onClick={onCloseAddProduct} variant="secondaryButton">
                     Cancel
                   </Button>
-                  <Button colorScheme="purple" mr={3} onClick={onProductAdd} variant="primaryButton">
+                  <Button
+                    colorScheme="purple"
+                    mr={3}
+                    onClick={onProductAdd}
+                    variant="primaryButton"
+                    isDisabled={!isFormValid}
+                  >
                     Add
                   </Button>
                 </HStack>

--- a/src/components/promotions/CreateUpdateForm.tsx
+++ b/src/components/promotions/CreateUpdateForm.tsx
@@ -143,8 +143,10 @@ function CreateUpdateForm({promotion}: CreateUpdateFormProps) {
             values,
             errors,
             touched,
+            dirty,
             handleBlur,
             handleSubmit,
+            isValid,
             isSubmitting,
             setFieldValue,
             resetForm
@@ -234,7 +236,7 @@ function CreateUpdateForm({promotion}: CreateUpdateFormProps) {
                               </NumberInput>
                             </Box>
                             <Box>
-                              <InputControl name="Code" label="Coupon Code" helperText="" />
+                              <InputControl name="Code" label="Coupon Code" helperText="" isRequired />
                               <Divider mt="15" mb="15" />
                               <TextareaControl name="FinePrint" label="Fine Print" />
                               <Divider mt="15" mb="15" />
@@ -301,10 +303,14 @@ function CreateUpdateForm({promotion}: CreateUpdateFormProps) {
                         <TabPanel>
                           <SimpleGrid columns={2} spacing={10}>
                             <Box>
-                              <EligibleExpressionField name="EligibleExpression" label="Eligible Expression" />
+                              <EligibleExpressionField
+                                name="EligibleExpression"
+                                label="Eligible Expression"
+                                isRequired
+                              />
                             </Box>
                             <Box>
-                              <TextareaControl name="ValueExpression" label="Value Expression" />
+                              <TextareaControl name="ValueExpression" label="Value Expression" isRequired />
                             </Box>
                           </SimpleGrid>
                           <ExpressionBuilder />
@@ -315,7 +321,12 @@ function CreateUpdateForm({promotion}: CreateUpdateFormProps) {
                   <GridItem pl="2" area={"footer"}>
                     <Divider mt="15" mb="15" />
                     <ButtonGroup>
-                      <Button variant="primaryButton" type="submit" isLoading={isSubmitting}>
+                      <Button
+                        variant="primaryButton"
+                        type="submit"
+                        isLoading={isSubmitting}
+                        isDisabled={!isValid || !dirty}
+                      >
                         Save
                       </Button>
                       <Button

--- a/src/components/suppliers/CreateUpdateForm.tsx
+++ b/src/components/suppliers/CreateUpdateForm.tsx
@@ -1,6 +1,6 @@
 import * as Yup from "yup"
 import {Box, Button, ButtonGroup, Flex, Stack} from "@chakra-ui/react"
-import {InputControl, PercentComplete, SwitchControl} from "components/formik"
+import {InputControl, SwitchControl} from "components/formik"
 import Card from "../card/Card"
 import {Formik} from "formik"
 import {Supplier, Suppliers} from "ordercloud-javascript-sdk"
@@ -54,25 +54,28 @@ function CreateUpdateForm({supplier}: CreateUpdateFormProps) {
               values,
               errors,
               touched,
+              dirty,
               handleChange,
               handleBlur,
               handleSubmit,
+              isValid,
               isSubmitting,
               setFieldValue,
               resetForm
             }) => (
               <Box as="form" onSubmit={handleSubmit as any}>
                 <Stack spacing={5}>
-                  <InputControl name="Name" label="Supplier Name" />
+                  <InputControl name="Name" label="Supplier Name" isRequired />
                   <SwitchControl name="Active" label="Active" />
                   <SwitchControl name="AllBuyersCanOrder" label="All Buyers Can Order" />
-                  {isCreating ? (
-                    <PercentComplete />
-                  ) : (
-                    <InputControl name="DateCreated" label="Date created" isReadOnly />
-                  )}
+                  {!isCreating && <InputControl name="DateCreated" label="Date created" isReadOnly />}
                   <ButtonGroup>
-                    <Button variant="primaryButton" type="submit" isLoading={isSubmitting}>
+                    <Button
+                      variant="primaryButton"
+                      type="submit"
+                      isLoading={isSubmitting}
+                      isDisabled={!isValid || !dirty}
+                    >
                       Save
                     </Button>
                     <Button

--- a/src/components/usergroups/CreateUpdateForm.tsx
+++ b/src/components/usergroups/CreateUpdateForm.tsx
@@ -40,7 +40,7 @@ function CreateUpdateForm({userGroup, ocService}: CreateUpdateFormProps) {
   async function updateUserGroup(fields: UserGroup) {
     await ocService.Save(parentId, router.query.usergroupid, fields)
     successToast({
-      description: "Buyer updated successfully."
+      description: "User Group updated successfully."
     })
     router.back()
   }
@@ -55,19 +55,26 @@ function CreateUpdateForm({userGroup, ocService}: CreateUpdateFormProps) {
               values,
               errors,
               touched,
+              dirty,
               handleChange,
               handleBlur,
               handleSubmit,
+              isValid,
               isSubmitting,
               setFieldValue,
               resetForm
             }) => (
               <Box as="form" onSubmit={handleSubmit as any}>
                 <Stack spacing={5}>
-                  <InputControl name="Name" label="User Group Name" />
+                  <InputControl name="Name" label="User Group Name" isRequired />
                   <TextareaControl name="Description" label="Description" />
                   <ButtonGroup>
-                    <Button variant="primaryButton" type="submit" isLoading={isSubmitting}>
+                    <Button
+                      variant="primaryButton"
+                      type="submit"
+                      isLoading={isSubmitting}
+                      isDisabled={!isValid || !dirty}
+                    >
                       Save
                     </Button>
                     <Button

--- a/src/components/users/CreateUpdateForm.tsx
+++ b/src/components/users/CreateUpdateForm.tsx
@@ -22,7 +22,7 @@ function CreateUpdateForm({user, ocService}: CreateUpdateFormProps) {
     FirstName: Yup.string().required("First Name is required"),
     LastName: Yup.string().required("Last Name is required"),
     Email: Yup.string().email("Email is invalid").required("Email is required"),
-    Password: Yup.string().required("Password is required").min(10, "Password must be at least 6 characters"),
+    Password: Yup.string().required("Password is required").min(10, "Password must be at least 10 characters"),
     ConfirmPassword: Yup.string()
       .transform((x) => (x === "" ? undefined : x))
       .when("Password", (password, schema) => {
@@ -68,19 +68,21 @@ function CreateUpdateForm({user, ocService}: CreateUpdateFormProps) {
               values,
               errors,
               touched,
+              dirty,
               handleChange,
               handleBlur,
               handleSubmit,
+              isValid,
               isSubmitting,
               setFieldValue,
               resetForm
             }) => (
               <Box as="form" onSubmit={handleSubmit as any}>
                 <Stack spacing={5}>
-                  <InputControl name="Username" label="Username" />
-                  <InputControl name="FirstName" label="First name" />
-                  <InputControl name="LastName" label="Last name" />
-                  <InputControl name="Email" label="Email" />
+                  <InputControl name="Username" label="Username" isRequired />
+                  <InputControl name="FirstName" label="First name" isRequired />
+                  <InputControl name="LastName" label="Last name" isRequired />
+                  <InputControl name="Email" label="Email" isRequired />
                   <InputControl name="Phone" label="Phone" />
                   <SwitchControl name="Active" label="Active" />
                   {/* {isAddMode && (  This has been commented to fix a validation bug duing update */}
@@ -94,6 +96,7 @@ function CreateUpdateForm({user, ocService}: CreateUpdateFormProps) {
                         pr="4.5rem"
                         type={show ? "text" : "password"}
                         placeholder="Enter password"
+                        isRequired
                       />
                       <Button position="absolute" right="2px" top="2px" size="sm" onClick={handleClick}>
                         {show ? "Hide" : "Show"}
@@ -107,12 +110,18 @@ function CreateUpdateForm({user, ocService}: CreateUpdateFormProps) {
                       pr="4.5rem"
                       type={show ? "text" : "password"}
                       placeholder="Enter password"
+                      isRequired
                     />
                     <ErrorMessage name="ConfirmPassword" />
                   </>
                   {/* )} */}
                   <ButtonGroup>
-                    <Button variant="primaryButton" type="submit" isLoading={isSubmitting}>
+                    <Button
+                      variant="primaryButton"
+                      type="submit"
+                      isLoading={isSubmitting}
+                      isDisabled={!isValid || !dirty}
+                    >
                       Save
                     </Button>
                     <Button


### PR DESCRIPTION
1) Removes the progress bar from single-page forms (buyer and supplier add screens)
2) Adds isRequired prop to multiple forms' FormControls, which uses Chakra to generate a red asterisk to flag a field as required
3) Adds isDisabled prop to multiple forms' Save buttons to prevent Save button from appearing clickable when the form is invalid or hasn't been changed