### PR TITLE
Add markdown files for contributors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,0 @@
-# Changelog
-All notable changes to the repository will be documented in this file starting with the initial public release.
-
-1.0.0-alpha.1
-- Initial public release, no changes to report.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,18 +6,18 @@ Every contribution / pull request needs to be associated to one or more [GitHub 
 
 Before logging a new issue, please check to see if your concern / idea has already been logged.
 
-Once an issue is moved (by a project moderator) to the "Todo" column in the project backlog it is considered ready to be worked on. Please assign yourself and mark the issue as "In Progress" once development has started in order to avoid duplicate work.
+Once an issue is moved (by a project maintainer) to the "Todo" column in the project backlog it is considered ready to be worked on. Please assign yourself and mark the issue as "In Progress" once development has started in order to avoid duplicate work.
 
 ## Development
-1. Fork and clone the template repository locally, ensure that you copy ALL branches
+1. Fork and clone the template repository locally
 2. Follow the working locally guide outlined in the main README.md
-3. After you have completed development, run `npm test` (if you wrote unit tests) and/or `npm build` locally to ensure everything still works.
+3. After you have completed development, run `npm test` and `npm build` locally to ensure everything still works.
 4. Feel free to push changes to your forked development branch or create a new feature branch if it's a larger change.
-5. Open a pull request to the master fork `development` branch. Ensure that the pull request is linked to the issues you are addressing in the pull request and include a verbose description of the changes / fix / feature.
-6. A maintainer will review your pull request in time. They will either approve and merge or request further changes from the author.
+5. Open a pull request to the main repository `development` branch. Ensure that the pull request is linked to the issues you are addressing in the pull request and include a verbose description of the changes / fix / feature.
+6. A maintainer will review your pull request. They will either approve and merge or request further changes.
 7. Once your PR is merged, it will be slotted for the next release (merge into `main` branch).
+
+> **Important Note** - Ensure that you have recently pulled the latest from the main repository `development` branch before you begin new development.
 
 ## Repository Structure
 Coming soon! A brief description of the directory structure their general purposes.
-
-> **Important Note** - Ensure that you have recently pulled the latest from the master fork `development` branch before you begin development.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ To deploy your local project to Vercel, push it to public GitHub/GitLab/Bitbucke
 Check out our [Contributing](./CONTRIBUTING.md) guide.
 
 ## Changelog
-Changes from release-to-release are tracked in the [Changelog](./CHANGELOG.md).
+Changes from release-to-release are tracked in the [Changelog wiki page](https://github.com/Sitecore/Sitecore.Commerce.Headstart.ReactAdmin/wiki/Changelog).
 
 ## Roadmap
 Larger roadmap items are outlined in the [project milestones](https://github.com/Sitecore/Sitecore.Commerce.Headstart.ReactAdmin/milestones)


### PR DESCRIPTION
This is for #23

Updated the main README.md with warning about the repository still undergoing major changes and links to a CONTRIBUTING.md file and CHANGELOG.md file.

I'm not sure what our first version will be so for now I just used `1.0.0-alpha.1`

For now the roadmap just links users to the milestones page.

Once these pages are solidified I will make updates to the Wiki