### PR TITLE
Add/remove facets to a product

### DIFF
--- a/src/components/products/detail/ProductDetail.tsx
+++ b/src/components/products/detail/ProductDetail.tsx
@@ -103,7 +103,7 @@ export default function ProductDetail({
       const { ID, Name, xp: { Options } } = facet;
       const optionsWithValues = Options.map(option => ({
         facetOptionName: option,
-        value: facetsOnProduct[ID] ? facetsOnProduct[ID].includes(option) : false
+        value: (facetsOnProduct && facetsOnProduct[ID] && facetsOnProduct[ID].includes(option)) || false
       }));
 
       return {

--- a/src/components/products/detail/ProductDetail.tsx
+++ b/src/components/products/detail/ProductDetail.tsx
@@ -50,6 +50,8 @@ import { ISpec } from "types/ordercloud/ISpec"
 import ProductSpecs from "../ProductSpecs"
 import { IVariant } from "types/ordercloud/IVariant"
 import ProductVariants from "../ProductVariants"
+import {FacetsForm} from "./forms/FacetsForm/FacetsForm"
+import { IProductFacet } from "types/ordercloud/IProductFacet"
 
 export type ProductDetailTab = "Details" | "Pricing" | "Variants" | "Media" | "Facets" | "Customization" | "SEO"
 
@@ -70,6 +72,7 @@ interface ProductDetailProps {
   defaultPriceSchedule?: IPriceSchedule
   specs?: ISpec[]
   variants?: IVariant[]
+  facets?: IProductFacet[]
 }
 export default function ProductDetail({
   showTabbedView,
@@ -77,7 +80,8 @@ export default function ProductDetail({
   product,
   defaultPriceSchedule = {} as IPriceSchedule,
   specs,
-  variants
+  variants,
+  facets
 }: ProductDetailProps) {
   const router = useRouter()
   const successToast = useSuccessToast()
@@ -94,9 +98,27 @@ export default function ProductDetail({
   }
   const [viewVisibility, setViewVisibility] = useState(initialViewVisibility)
 
+  const createFormFacets = (facetList: IProductFacet[], facetsOnProduct: any) => {
+    const formattedFacets = facetList.map(facet => {
+      const { ID, Name, xp: { Options } } = facet;
+      const optionsWithValues = Options.map(option => ({
+        facetOptionName: option,
+        value: facetsOnProduct[ID] ? facetsOnProduct[ID].includes(option) : false
+      }));
+
+      return {
+        ID,
+        Name,
+        Options: optionsWithValues
+      };
+    });
+
+    return(formattedFacets)
+  }
+
   const initialValues = product
     ? withDefaultValuesFallback(
-        {Product: cloneDeep(product), DefaultPriceSchedule: cloneDeep(defaultPriceSchedule)},
+        {Product: cloneDeep(product), DefaultPriceSchedule: cloneDeep(defaultPriceSchedule), Facets: cloneDeep(createFormFacets(facets, product?.xp?.Facets))},
         defaultValues
       )
     : makeNestedObject(defaultValues)
@@ -112,14 +134,39 @@ export default function ProductDetail({
     mode: "onBlur"
   })
 
+  const generateUpdatedFacets = (facets) => {
+    const updatedFacetsOnProduct = {};
+  
+    facets.forEach((facet) => {
+      const { ID, Options } = facet;
+      const filteredOptions = Options.filter((option) => option.value === true);
+  
+      if (filteredOptions.length > 0) {
+        updatedFacetsOnProduct[ID] = filteredOptions.map((option) => option.facetOptionName);
+      } else {
+        updatedFacetsOnProduct[ID] = [];
+      }
+    });
+  
+    return updatedFacetsOnProduct;
+  };
+
   const onSubmit = async (fields) => {
+    const updatedFacetsOnProduct = generateUpdatedFacets(fields.Facets);
+
     // create/update product
     if (isCreatingNew) {
-      product = await Products.Create<IProduct>({...fields.Product, DefaultPriceScheduleID: defaultPriceSchedule.ID})
+      product = await Products.Create<IProduct>({...fields.Product, DefaultPriceScheduleID: defaultPriceSchedule.ID, 
+        xp: {
+          Facets: updatedFacetsOnProduct
+        }})
     } else {
       const productDiff = getObjectDiff(product, fields.Product)
       product = await Products.Patch<IProduct>(product.ID, {
-        ...productDiff
+        ...productDiff,
+        xp: {
+          Facets: updatedFacetsOnProduct
+        }
       })
     }
 
@@ -327,26 +374,7 @@ export default function ProductDetail({
               {viewVisibility.Facets && (
                 <TabPanel p={0} mt={6}>
                   <Card w="100%">
-                    <CardHeader display="flex" alignItems={"center"}>
-                      <Button variant="outline" colorScheme="accent" ml="auto">
-                        Add Facet
-                      </Button>
-                    </CardHeader>
-                    <CardBody>
-                      <Box
-                        p={6}
-                        display="flex"
-                        flexDirection={"column"}
-                        alignItems={"center"}
-                        justifyContent={"center"}
-                        minH={"xs"}
-                      >
-                        <Icon as={TbCactus} fontSize={"5xl"} strokeWidth={"2px"} color="accent.500" />
-                        <Heading colorScheme="secondary" fontSize="xl">
-                          This product has no facets
-                        </Heading>
-                      </Box>
-                    </CardBody>
+                    <FacetsForm control={control} trigger={trigger} facetList={facets} productFacets={product?.xp?.Facets}/>
                   </Card>
                 </TabPanel>
               )}

--- a/src/components/products/detail/forms/FacetsForm/FacetsForm.tsx
+++ b/src/components/products/detail/forms/FacetsForm/FacetsForm.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect } from 'react';
+import { Control, FieldValues, UseFormTrigger, useWatch } from 'react-hook-form';
+import { Box, Card, CardBody, Flex, Grid, Text } from '@chakra-ui/react';
+import { IProductFacet } from 'types/ordercloud/IProductFacet';
+import FacetCheckboxControl from '@/components/react-hook-form/form-checkbox/facet-checkbox-control';
+
+interface FacetOptionsProps {
+  facet: IProductFacet;
+  control: Control<FieldValues, any>;
+  trigger: UseFormTrigger<any>;
+  productFacets?: any;
+  index?: number;
+}
+
+const FacetOptions = ({ facet, control, trigger, productFacets, index }: FacetOptionsProps) => {
+  const watchFields = useWatch({ control, name: `Facets[${index}].Options` });
+
+  useEffect(() => {
+    trigger(`Facets[${index}].Options`);
+  }, [watchFields, trigger, index]);
+
+  const formattedOptions = facet.xp?.Options || [];
+
+  return (
+    <Box>
+      <Flex flexWrap="wrap" gap={4}>
+        {formattedOptions.map((facetOption, i) => {
+          return (
+            <FacetCheckboxControl
+              key={facetOption}
+              name={`Facets.${index}.Options.${i}.value`}
+              control={control}
+              label={facetOption}
+              productFacets={productFacets}
+            />
+          );
+        })}
+      </Flex>
+    </Box>
+  );
+};
+
+interface FacetTableProps {
+  control: Control<FieldValues, any>;
+  trigger: UseFormTrigger<any>;
+  facetList: IProductFacet[];
+  productFacets?: any;
+}
+
+const FacetTable = ({ control, trigger, facetList, productFacets }: FacetTableProps) => {
+  return (
+    <Card>
+      <CardBody gap={4}>
+        <Grid gap={4}>
+          {facetList.map((facet, index) => (
+            <div key={facet.ID}>
+              <Text as="h3" fontWeight="bold">{facet.Name}</Text>
+              <FacetOptions facet={facet} control={control} trigger={trigger} productFacets={productFacets} index={index} />
+            </div>
+          ))}
+        </Grid>
+      </CardBody>
+    </Card>
+  );
+};
+
+interface FacetFormProps {
+  control: Control<FieldValues, any>;
+  trigger: UseFormTrigger<any>;
+  facetList: IProductFacet[];
+  productFacets?: any;
+}
+
+export function FacetsForm({ control, trigger, facetList, productFacets }: FacetFormProps) {
+  return (
+    <>
+      <FacetTable control={control} trigger={trigger} facetList={facetList} productFacets={productFacets} />
+    </>
+  );
+}

--- a/src/components/products/detail/forms/FacetsForm/defaultValues.ts
+++ b/src/components/products/detail/forms/FacetsForm/defaultValues.ts
@@ -1,0 +1,8 @@
+import * as fieldNames from "./fieldNames"
+import {ValuesType} from "types/type-helpers/ValuesType"
+
+type FieldName = ValuesType<typeof fieldNames>
+
+export const defaultValues: Record<FieldName, any> = {
+  [fieldNames.FACETS]: {}
+}

--- a/src/components/products/detail/forms/FacetsForm/fieldNames.ts
+++ b/src/components/products/detail/forms/FacetsForm/fieldNames.ts
@@ -1,0 +1,1 @@
+export const FACETS = "Product.xp.Facets"

--- a/src/components/products/detail/forms/FacetsForm/formShape.ts
+++ b/src/components/products/detail/forms/FacetsForm/formShape.ts
@@ -1,0 +1,10 @@
+import * as yup from "yup";
+import * as fieldNames from "./fieldNames";
+import {ValuesType} from "types/type-helpers/ValuesType"
+
+// Define your custom Facets object schema
+type FieldName = ValuesType<typeof fieldNames>
+
+export const formShape: Record<FieldName, any> = {
+  [fieldNames.FACETS]: yup.object(),
+}

--- a/src/components/products/detail/forms/FacetsForm/index.tsx
+++ b/src/components/products/detail/forms/FacetsForm/index.tsx
@@ -1,0 +1,4 @@
+export * from "./defaultValues"
+export * as form from "./FacetsForm"
+export * as fieldNames from "./fieldNames"
+export * from "./formShape"

--- a/src/components/products/detail/forms/meta.ts
+++ b/src/components/products/detail/forms/meta.ts
@@ -7,6 +7,7 @@ import * as inventoryForm from "./InventoryForm"
 import * as shippingForm from "./ShippingForm"
 import * as unitOfMeasureForm from "./UnitOfMeasureForm"
 import * as pricingForm from "./PricingForm"
+import * as facetsForm from "./FacetsForm"
 import {ProductDetailTab} from "../ProductDetail"
 
 export const defaultValues = {
@@ -15,7 +16,8 @@ export const defaultValues = {
   ...inventoryForm.defaultValues,
   ...shippingForm.defaultValues,
   ...unitOfMeasureForm.defaultValues,
-  ...pricingForm.defaultValues
+  ...pricingForm.defaultValues,
+  ...facetsForm.defaultValues
 }
 
 export const validationSchema = yup.object().shape(
@@ -25,7 +27,8 @@ export const validationSchema = yup.object().shape(
     ...inventoryForm.formShape,
     ...shippingForm.formShape,
     ...unitOfMeasureForm.formShape,
-    ...pricingForm.formShape
+    ...pricingForm.formShape,
+    ...facetsForm.formShape
   })
 )
 
@@ -35,12 +38,12 @@ export const tabFieldNames: Record<ProductDetailTab, any[]> = {
     ...values(detailsForm.fieldNames),
     ...values(inventoryForm.fieldNames),
     ...values(shippingForm.fieldNames),
-    ...values(unitOfMeasureForm.fieldNames)
+    ...values(unitOfMeasureForm.fieldNames),
   ],
   Pricing: [...values(pricingForm.fieldNames)],
   Variants: [],
   Media: [],
-  Facets: [],
+  Facets: [...values(facetsForm.fieldNames)],
   Customization: [],
   SEO: []
 }

--- a/src/components/react-hook-form/form-checkbox/facet-checkbox-control.tsx
+++ b/src/components/react-hook-form/form-checkbox/facet-checkbox-control.tsx
@@ -1,0 +1,46 @@
+import { Checkbox, CheckboxProps } from "@chakra-ui/react";
+import React, { FC } from "react";
+import { Control, FieldValues, useController } from "react-hook-form";
+import { isRequiredField } from "utils";
+
+type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
+
+export type FacetCheckboxControlProps = Overwrite<CheckboxProps, { value?: any }> & {
+  name: string;
+  control: Control<FieldValues, any>;
+  label?: string;
+  validationSchema?: any;
+  productFacets?: Record<string, string[]>;
+};
+
+export const FacetCheckboxControl: FC<FacetCheckboxControlProps> = (props: FacetCheckboxControlProps) => {
+    const { name, control, label, children, validationSchema, productFacets, ...rest } = props;
+    const {
+      field,
+      fieldState: { isTouched },
+      formState: { errors, isSubmitting }
+    } = useController({ name, control });
+    const error = errors[name];
+  
+    const isRequired = isRequiredField(validationSchema, field.name);
+  
+    return (
+      <Checkbox
+        {...field}
+        isRequired={isRequired}
+        isInvalid={!!error && isTouched}
+        isChecked={field.value}
+        isDisabled={isSubmitting}
+        {...rest}
+      >
+        {label}
+        {children}
+      </Checkbox>
+    );
+  };
+  
+  
+
+FacetCheckboxControl.displayName = "FacetCheckboxControl";
+
+export default FacetCheckboxControl;

--- a/src/hooks/useProductDetail.ts
+++ b/src/hooks/useProductDetail.ts
@@ -1,11 +1,13 @@
 import {ProductDetailTab} from "@/components/products/detail/ProductDetail"
+import { Console } from "console"
 import {useRouter} from "next/router"
-import {PriceSchedules, Products, Spec, SpecOption, SpecProductAssignment, Specs, Variant} from "ordercloud-javascript-sdk"
+import {PriceSchedules, Products, Spec, SpecOption, SpecProductAssignment, Specs, Variant, ProductFacets} from "ordercloud-javascript-sdk"
 import {useState, useEffect} from "react"
 import {IPriceSchedule} from "types/ordercloud/IPriceSchedule"
 import {IProduct} from "types/ordercloud/IProduct"
 import { ISpec } from "types/ordercloud/ISpec"
 import { IVariant } from "types/ordercloud/IVariant"
+import {IProductFacet} from "types/ordercloud/IProductFacet"
 
 export function useProductDetail() {
   const {isReady, query, push} = useRouter()
@@ -13,11 +15,17 @@ export function useProductDetail() {
   const [defaultPriceSchedule, setDefaultPriceSchedule] = useState(null as IPriceSchedule)
   const [specs, setSpecs] = useState(null as ISpec[])
   const [variants, setVariants] = useState(null as IVariant[])
+  const [facets, setFacets] = useState([] as IProductFacet[])
   const [showTabbedView, setShowTabbedView] = useState(true)
   const [loading, setLoading] = useState(true)
   const [initialTab, setInitialTab] = useState("Details" as ProductDetailTab)
 
   useEffect(() => {
+    (async () => {
+      const _facets = await ProductFacets.List<IProductFacet>({pageSize: 100})
+      setFacets(_facets.Items)
+    })()
+
     const getProduct = async () => {
       const _product = await fetchProduct();
       if (_product) {
@@ -112,5 +120,5 @@ export function useProductDetail() {
     }
   }, [isReady, query, push])
 
-  return {product, defaultPriceSchedule, specs, variants, loading, showTabbedView, initialTab}
+  return {product, defaultPriceSchedule, specs, variants, facets, loading, showTabbedView, initialTab}
 }

--- a/src/pages/products/[productid].tsx
+++ b/src/pages/products/[productid].tsx
@@ -39,7 +39,7 @@ export async function getServerSideProps() {
 }
 
 const ProductDetailPage = () => {
-  const {product, defaultPriceSchedule, specs, variants, loading, showTabbedView, initialTab} = useProductDetail()
+  const {product, defaultPriceSchedule, specs, variants, facets, loading, showTabbedView, initialTab} = useProductDetail()
 
   if (loading || !product) {
     return (
@@ -82,6 +82,7 @@ const ProductDetailPage = () => {
       defaultPriceSchedule={defaultPriceSchedule}
       specs={specs}
       variants={variants}
+      facets={facets}
     />
   )
 }

--- a/src/types/ordercloud/IProduct.ts
+++ b/src/types/ordercloud/IProduct.ts
@@ -6,6 +6,7 @@ export interface IProductXp {
   // add custom xp properties required for this project here
   Images?: XpImage[]
   UnitOfMeasure?: string
+  Facets?: { [key: string]: any[] }
 }
 
 export interface XpImage {

--- a/src/types/ordercloud/IProductFacet.ts
+++ b/src/types/ordercloud/IProductFacet.ts
@@ -4,4 +4,5 @@ export type IProductFacet = ProductFacet<IProductFacetXp>
 
 export interface IProductFacetXp {
   // add custom xp properties required for this project here
+  Options: any[]
 }


### PR DESCRIPTION
1) Adds the ability to add/remove facets from a product using the facets/facet options determined in the Admin > Settings section.
2) This does deviate a little from the Figma and uses simple checkboxes instead of the complexity involved with multi-select input fields that would require a user to search and know what a facet option would be.