### PR TITLE
Make it easier to deploy a static site and fix loading indicator issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "postbuild": "next-sitemap --config next-sitemap.config.js",
     "start": "next start",
     "lint": "next lint",
+    "export": "next export",
     "lint:fix": "eslint src --fix && npm run format",
     "type-check": "tsc --noEmit",
     "format": "prettier --write src",

--- a/src/components/layout/ContentHeader.tsx
+++ b/src/components/layout/ContentHeader.tsx
@@ -2,15 +2,20 @@ import {Container} from "@chakra-ui/react"
 import BuyerContextSwitch from "components/buyers/BuyerContextSwitch"
 import {Breadcrumbs} from "../navigation/Breadcrumbs"
 import SupplierContextSwitch from "components//suppliers/SupplierContextSwitch"
+import {useRouter} from "hooks/useRouter"
 
-const ContentHeader = (props) => {
-  return props.header ? (
+const ContentHeader = () => {
+  const router = useRouter()
+  const path = router.asPath
+  const pathParts = router.asPath.split("/")
+
+  return (
     <Container px={[4, 6, 8]} pt={[6, 8, 10]} bg={"st.mainBackgroundColor"} maxW="100%">
-      {props?.header?.metas?.hasBreadcrumbs && <Breadcrumbs />}
-      {props?.header?.metas?.hasBuyerContextSwitch && <BuyerContextSwitch />}
-      {props?.header?.metas?.hasSupplierContextSwitch && <SupplierContextSwitch />}
+      {path !== "/dashboard" && path !== "/" && <Breadcrumbs />}
+      {path.startsWith("/buyers") && pathParts.length > 2 && <BuyerContextSwitch />}
+      {path.startsWith("/suppliers") && pathParts.length > 2 && <SupplierContextSwitch />}
     </Container>
-  ) : null
+  )
 }
 
 export default ContentHeader

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -28,7 +28,7 @@ const Layout = (props) => {
           <DesktopSideBarMenu />
         </Hide>
         <Flex flexFlow={"column nowrap"} overflowX="hidden">
-          <ContentHeader {...props} />
+          <ContentHeader />
           {props.children}
           <ContentFooter />
         </Flex>

--- a/src/pages/buyers/[buyerid]/catalogs/[catalogid]/categories/[categoryid].tsx
+++ b/src/pages/buyers/[buyerid]/catalogs/[catalogid]/categories/[categoryid].tsx
@@ -1,27 +1,11 @@
 import {useEffect, useState} from "react"
 import {CategoryForm} from "@/components/categories/CategoryForm"
-import {Box, Container, Skeleton} from "@chakra-ui/react"
+import {Container, Skeleton} from "@chakra-ui/react"
 import {Categories, Category} from "ordercloud-javascript-sdk"
 import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 import {useRouter} from "hooks/useRouter"
 import {ICategory} from "types/ordercloud/ICategoryXp"
-
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Edit category",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
 
 const CategoryListItem = (props) => {
   const router = useRouter()

--- a/src/pages/buyers/[buyerid]/catalogs/[catalogid]/categories/index.tsx
+++ b/src/pages/buyers/[buyerid]/catalogs/[catalogid]/categories/index.tsx
@@ -24,22 +24,6 @@ import TreeView from "components/dndtreeview/TreeView"
 import {ocNodeModel} from "@minoru/react-dnd-treeview"
 import {useRouter} from "hooks/useRouter"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Categories List",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const CategoriesList = (props) => {
   const [categoriesTreeView, setCategoriesTreeView] = useState([])
   const [selectedNode, setSelectedNode] = useState<ocNodeModel>(null)

--- a/src/pages/buyers/[buyerid]/catalogs/[catalogid]/categories/new.tsx
+++ b/src/pages/buyers/[buyerid]/catalogs/[catalogid]/categories/new.tsx
@@ -3,22 +3,6 @@ import {Box} from "@chakra-ui/react"
 import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Create a new category",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const ProtectedNewCategoryPage = () => {
   return (
     <ProtectedContent hasAccess={appPermissions.BuyerManager}>

--- a/src/pages/buyers/[buyerid]/catalogs/[catalogid]/index.tsx
+++ b/src/pages/buyers/[buyerid]/catalogs/[catalogid]/index.tsx
@@ -1,28 +1,11 @@
 import {Catalog, Catalogs} from "ordercloud-javascript-sdk"
 import {useEffect, useState} from "react"
-
 import {CatalogForm} from "@/components/catalogs/CatalogForm"
 import {ICatalog} from "types/ordercloud/ICatalog"
 import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 import {useRouter} from "hooks/useRouter"
 import {Container, Skeleton} from "@chakra-ui/react"
-
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Edit catalog",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
 
 const CatalogListItem = () => {
   const router = useRouter()

--- a/src/pages/buyers/[buyerid]/catalogs/index.tsx
+++ b/src/pages/buyers/[buyerid]/catalogs/index.tsx
@@ -2,22 +2,6 @@ import React from "react"
 import {useRouter} from "hooks/useRouter"
 import BuyerCatalogsList from "@/components/buyercatalogs/list/BuyerCatalogsList"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Catalogs List",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const CatalogsList = () => {
   const router = useRouter()
   const buyerid = router.query.buyerid as string

--- a/src/pages/buyers/[buyerid]/catalogs/new.tsx
+++ b/src/pages/buyers/[buyerid]/catalogs/new.tsx
@@ -2,22 +2,6 @@ import {CatalogForm} from "components/catalogs"
 import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Create a new catalog",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const ProtectedNewCatalogPage = () => {
   return (
     <ProtectedContent hasAccess={appPermissions.BuyerManager}>

--- a/src/pages/buyers/[buyerid]/index.tsx
+++ b/src/pages/buyers/[buyerid]/index.tsx
@@ -7,23 +7,6 @@ import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 import {useRouter} from "hooks/useRouter"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-/* TODO Ask if this is the way to go or better to have getStaticProps + GetStaticPath in this case */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Edit buyer",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const BuyerListItem = () => {
   const router = useRouter()
   const [buyer, setBuyer] = useState({} as Buyer)

--- a/src/pages/buyers/[buyerid]/usergroups/[usergroupid].tsx
+++ b/src/pages/buyers/[buyerid]/usergroups/[usergroupid].tsx
@@ -1,28 +1,11 @@
 import {UserGroup, UserGroups} from "ordercloud-javascript-sdk"
 import {useEffect, useState} from "react"
-
 import {Box, Container, Skeleton} from "@chakra-ui/react"
 import {UserGroupFormForm} from "../../../../components/usergroups/UserGroupForm"
 import {IBuyerUserGroup} from "types/ordercloud/IBuyerUserGroup"
 import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 import {useRouter} from "hooks/useRouter"
-
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Edit user group",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
 
 const UserGroupListItem = () => {
   const router = useRouter()

--- a/src/pages/buyers/[buyerid]/usergroups/index.tsx
+++ b/src/pages/buyers/[buyerid]/usergroups/index.tsx
@@ -2,22 +2,6 @@ import React from "react"
 import {useRouter} from "hooks/useRouter"
 import BuyerUserGroupList from "@/components/buyerusergroups/list/BuyerUserGroupList"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "User groups List",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const UserGroupsList = () => {
   const router = useRouter()
   const buyerid = router.query.buyerid as string

--- a/src/pages/buyers/[buyerid]/usergroups/new.tsx
+++ b/src/pages/buyers/[buyerid]/usergroups/new.tsx
@@ -3,22 +3,6 @@ import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 import {UserGroups} from "ordercloud-javascript-sdk"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Create a new user group",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const ProtectedNewUserGroupPage = () => {
   return (
     <ProtectedContent hasAccess={appPermissions.BuyerManager}>

--- a/src/pages/buyers/[buyerid]/users/[userid].tsx
+++ b/src/pages/buyers/[buyerid]/users/[userid].tsx
@@ -7,22 +7,6 @@ import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 import {useRouter} from "hooks/useRouter"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Update user",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const UserListItem = () => {
   const router = useRouter()
   const [user, setUser] = useState({} as User)

--- a/src/pages/buyers/[buyerid]/users/index.tsx
+++ b/src/pages/buyers/[buyerid]/users/index.tsx
@@ -2,22 +2,6 @@ import React from "react"
 import {useRouter} from "hooks/useRouter"
 import BuyerUserList from "@/components/buyerusers/list/BuyerUserList"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Users List",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const UsersList = () => {
   const router = useRouter()
   const buyerid = router.query.buyerid as string

--- a/src/pages/buyers/[buyerid]/users/new.tsx
+++ b/src/pages/buyers/[buyerid]/users/new.tsx
@@ -3,22 +3,6 @@ import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 import {Users} from "ordercloud-javascript-sdk"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Create a new user",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const ProtectedNewBuyerUserPage = () => {
   return (
     <ProtectedContent hasAccess={appPermissions.BuyerManager}>

--- a/src/pages/buyers/index.tsx
+++ b/src/pages/buyers/index.tsx
@@ -2,21 +2,6 @@ import BuyerList from "@/components/buyers/list/BuyerList"
 import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getStaticProps() {
-  return {
-    props: {
-      header: {
-        title: "Buyers List",
-        metas: {
-          hasBreadcrumbs: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const ProtectedBuyersList = () => {
   return (
     <ProtectedContent hasAccess={appPermissions.BuyerManager}>

--- a/src/pages/buyers/new.tsx
+++ b/src/pages/buyers/new.tsx
@@ -2,21 +2,6 @@ import {BuyerForm} from "@/components/buyers/BuyerForm"
 import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getStaticProps() {
-  return {
-    props: {
-      header: {
-        title: "Create a new buyer",
-        metas: {
-          hasBreadcrumbs: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 function ProtectedNewBuyerUserPage() {
   return (
     <ProtectedContent hasAccess={appPermissions.BuyerManager}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,22 +1,19 @@
-import {Flex, Grid, useColorMode} from "@chakra-ui/react"
+import {Grid} from "@chakra-ui/react"
 import {NextSeo} from "next-seo"
 import Login from "../components/account/Login"
 import {useRouter} from "hooks/useRouter"
 
 const Home = () => {
   const {push} = useRouter()
-  const {colorMode, toggleColorMode} = useColorMode()
   const handleOnLoggedIn = () => {
     push("/dashboard")
   }
 
   return (
-    // <Flex direction="column" alignItems="center" justifyContent="center" minHeight="70vh" gap={4} mb={8} w="full">
     <Grid h={"100vh"} w={"100vw"} placeItems={"center center"}>
       <NextSeo title="Home" />
       <Login onLoggedIn={handleOnLoggedIn} />
     </Grid>
-    // </Flex>
   )
 }
 

--- a/src/pages/mysupplier/index.tsx
+++ b/src/pages/mysupplier/index.tsx
@@ -4,25 +4,7 @@ import {Container, Skeleton} from "@chakra-ui/react"
 import ProtectedContent from "components/auth/ProtectedContent"
 import {Me, Supplier, Suppliers} from "ordercloud-javascript-sdk"
 import {appPermissions} from "config/app-permissions.config"
-import {useRouter} from "hooks/useRouter"
 import {ISupplier} from "types/ordercloud/ISupplier"
-
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-/* TODO Ask if this is the way to go or better to have getStaticProps + GetStaticPath in this case */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "My supplier",
-        metas: {
-          hasBreadcrumbs: true,
-          hasSupplierContextSwitch: false
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
 
 const SupplierListItem = () => {
   const [supplier, setSupplier] = useState({} as Supplier)

--- a/src/pages/orders/[orderid].tsx
+++ b/src/pages/orders/[orderid].tsx
@@ -4,20 +4,6 @@ import {OrderDetail} from "@/components/orders/detail/OrderDetail"
 import {useOrderDetail} from "hooks/useOrderDetail"
 import {OrderDetailSkeleton} from "@/components/orders/detail/OrderDetailSkeleton"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Order Details",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false
-        }
-      }
-    }
-  }
-}
 const OrderDetailPage = () => {
   const orderDetailProps = useOrderDetail()
   if (orderDetailProps.loading) {

--- a/src/pages/orders/index.tsx
+++ b/src/pages/orders/index.tsx
@@ -2,21 +2,6 @@ import OrderList from "@/components/orders/list/OrderList"
 import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Orders List",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false
-        }
-      }
-    }
-  }
-}
-
 const ProtectedOrdersPage = () => (
   <ProtectedContent hasAccess={appPermissions.OrderManager}>
     <OrderList />

--- a/src/pages/orders/new.tsx
+++ b/src/pages/orders/new.tsx
@@ -4,20 +4,6 @@ import ProtectedContent from "components/auth/ProtectedContent"
 import React from "react"
 import {appPermissions} from "config/app-permissions.config"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "New Order",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false
-        }
-      }
-    }
-  }
-}
 const NewOrdersPage = () => {
   return (
     <Container maxW="full">

--- a/src/pages/products/[productid].tsx
+++ b/src/pages/products/[productid].tsx
@@ -4,21 +4,6 @@ import {ProductDetailSkeleton} from "@/components/products/detail/ProductDetailS
 import {appPermissions} from "config/app-permissions.config"
 import {useProductDetail} from "hooks/useProductDetail"
 
-/* This declares the page title and enables breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Product Detail",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false
-        }
-      }
-    }
-  }
-}
-
 const ProductDetailPage = () => {
   const {
     product,

--- a/src/pages/products/index.tsx
+++ b/src/pages/products/index.tsx
@@ -2,21 +2,6 @@ import ProductList from "@/components/products/list/ProductList"
 import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Products List",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false
-        }
-      }
-    }
-  }
-}
-
 const ProtectedProducts = () => {
   return (
     <ProtectedContent hasAccess={appPermissions.ProductManager}>

--- a/src/pages/products/new.tsx
+++ b/src/pages/products/new.tsx
@@ -4,21 +4,6 @@ import {ProductDetailSkeleton} from "@/components/products/detail/ProductDetailS
 import {appPermissions} from "config/app-permissions.config"
 import {useProductDetail} from "hooks/useProductDetail"
 
-/* This declares the page title and enables breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "New Product",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false
-        }
-      }
-    }
-  }
-}
-
 const ProductDetailPage = () => {
   const {loading, initialTab, facets} = useProductDetail()
 

--- a/src/pages/promotions/[promotionid].tsx
+++ b/src/pages/promotions/[promotionid].tsx
@@ -7,22 +7,6 @@ import {appPermissions} from "config/app-permissions.config"
 import {useRouter} from "hooks/useRouter"
 import {IPromotion} from "types/ordercloud/IPromotion"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Update promotion",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const PromotionItem = (props) => {
   const router = useRouter()
   const [promotion, setPromotion] = useState({} as Promotion)

--- a/src/pages/promotions/index.tsx
+++ b/src/pages/promotions/index.tsx
@@ -2,22 +2,6 @@ import PromotionList from "@/components/promotions/list/PromotionList"
 import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getStaticProps() {
-  return {
-    props: {
-      header: {
-        title: "Promotions List",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const ProtectedPromotionsList = () => {
   return (
     <ProtectedContent hasAccess={appPermissions.OrderManager}>

--- a/src/pages/promotions/new.tsx
+++ b/src/pages/promotions/new.tsx
@@ -2,22 +2,6 @@ import {PromotionForm} from "../../components/promotions/PromotionForm"
 import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getStaticProps() {
-  return {
-    props: {
-      header: {
-        title: "Create a new promotion",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitcher: false
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 function ProtectedNewPromotionPage() {
   return (
     <ProtectedContent hasAccess={appPermissions.OrderManager}>

--- a/src/pages/returns/[returnid].tsx
+++ b/src/pages/returns/[returnid].tsx
@@ -4,20 +4,6 @@ import {useOrderReturnDetail} from "hooks/useOrderReturnDetail"
 import {OrderReturnDetail} from "@/components/returns/detail/OrderReturnDetail"
 import {OrderReturnDetailSkeleton} from "@/components/returns/detail/OrderReturnDetailSkeleton"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Return Details",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false
-        }
-      }
-    }
-  }
-}
 const OrderReturnDetailPage = () => {
   const orderReturnDetailProps = useOrderReturnDetail()
   if (orderReturnDetailProps.loading) {

--- a/src/pages/returns/index.tsx
+++ b/src/pages/returns/index.tsx
@@ -2,21 +2,6 @@ import OrderReturnList from "@/components/returns/list/OrderReturnList"
 import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Returns List",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false
-        }
-      }
-    }
-  }
-}
-
 const ProtectedReturnsPage = () => {
   return (
     <ProtectedContent hasAccess={appPermissions.OrderManager}>

--- a/src/pages/settings/adminaddresses/[adminaddressid].tsx
+++ b/src/pages/settings/adminaddresses/[adminaddressid].tsx
@@ -7,21 +7,6 @@ import {appPermissions} from "config/app-permissions.config"
 import {useRouter} from "hooks/useRouter"
 import {IAdminAddress} from "types/ordercloud/IAdminAddress"
 
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Edit admin address",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const AdminAddressListItem = () => {
   const router = useRouter()
   const [adminAddress, setAdminAddress] = useState({} as Address)

--- a/src/pages/settings/adminaddresses/index.tsx
+++ b/src/pages/settings/adminaddresses/index.tsx
@@ -2,21 +2,6 @@ import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 import AdminAddressList from "@/components/adminaddresses/list/AdminAddressList"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Admin Address List",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false
-        }
-      }
-    }
-  }
-}
-
 const ProtectedAdminAddresses = () => {
   return (
     <ProtectedContent hasAccess={appPermissions.SettingsManager}>

--- a/src/pages/settings/adminaddresses/new.tsx
+++ b/src/pages/settings/adminaddresses/new.tsx
@@ -2,21 +2,6 @@ import {AdminAddressForm} from "@/components/adminaddresses/AdminAddressForm"
 import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getStaticProps() {
-  return {
-    props: {
-      header: {
-        title: "Create a new admin address",
-        metas: {
-          hasBreadcrumbs: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 function ProtectedNewAdminAddressPage() {
   return (
     <ProtectedContent hasAccess={appPermissions.SettingsManager}>

--- a/src/pages/settings/adminusers/[adminuserid].tsx
+++ b/src/pages/settings/adminusers/[adminuserid].tsx
@@ -7,21 +7,6 @@ import {appPermissions} from "config/app-permissions.config"
 import {useRouter} from "hooks/useRouter"
 import {IAdminUser} from "types/ordercloud/IAdminUser"
 
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Edit admin user",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const AdminUserListItem = () => {
   const router = useRouter()
   const [adminUser, setAdminUser] = useState({} as User)

--- a/src/pages/settings/adminusers/index.tsx
+++ b/src/pages/settings/adminusers/index.tsx
@@ -2,21 +2,6 @@ import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 import AdminUserList from "@/components/adminusers/list/AdminUserList"
 
-/* This declares the page title and enables the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Admin Users List",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false
-        }
-      }
-    }
-  }
-}
-
 const ProtectedAdminUsers = () => {
   return (
     <ProtectedContent hasAccess={appPermissions.SettingsManager}>

--- a/src/pages/settings/adminusers/new.tsx
+++ b/src/pages/settings/adminusers/new.tsx
@@ -2,21 +2,6 @@ import {AdminUserForm} from "@/components/adminusers/AdminUserForm"
 import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getStaticProps() {
-  return {
-    props: {
-      header: {
-        title: "Create a new admin user",
-        metas: {
-          hasBreadcrumbs: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 function ProtectedNewAdminUserPage() {
   return (
     <ProtectedContent hasAccess={appPermissions.SettingsManager}>

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -7,20 +7,6 @@ import React from "react"
 import {appPermissions} from "config/app-permissions.config"
 import {Link} from "components/navigation/Link"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Settings",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false
-        }
-      }
-    }
-  }
-}
 const SettingsPage = () => {
   const color = useColorModeValue("boxTextColor.900", "boxTextColor.100")
   const boxBgColor = useColorModeValue("boxBgColor.100", "boxBgColor.600")

--- a/src/pages/settings/productfacets/[productfacetid].tsx
+++ b/src/pages/settings/productfacets/[productfacetid].tsx
@@ -7,22 +7,6 @@ import {ProductFacetForm} from "components/productfacets"
 import {useRouter} from "hooks/useRouter"
 import {IProductFacet} from "types/ordercloud/IProductFacet"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Edit product facet",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const ProductFacetsListItem = () => {
   const router = useRouter()
   const [productfacet, setProductFacet] = useState({} as ProductFacet)

--- a/src/pages/settings/productfacets/index.tsx
+++ b/src/pages/settings/productfacets/index.tsx
@@ -2,21 +2,6 @@ import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 import ProductFacetList from "@/components/productfacets/list/ProductFacetList"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Product Facets List",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false
-        }
-      }
-    }
-  }
-}
-
 const ProtectedProductFacets = () => {
   return (
     <ProtectedContent hasAccess={appPermissions.ProductManager}>

--- a/src/pages/settings/productfacets/new.tsx
+++ b/src/pages/settings/productfacets/new.tsx
@@ -4,21 +4,6 @@ import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 import {NextSeo} from "next-seo"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getStaticProps() {
-  return {
-    props: {
-      header: {
-        title: "Create a Product Facet",
-        metas: {
-          hasBreadcrumbs: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const NewProductFacetsPage = () => {
   return (
     <Container maxW="full">

--- a/src/pages/suppliers/[supplierid]/addresses/[supplieraddressid].tsx
+++ b/src/pages/suppliers/[supplierid]/addresses/[supplieraddressid].tsx
@@ -7,21 +7,6 @@ import {appPermissions} from "config/app-permissions.config"
 import {useRouter} from "hooks/useRouter"
 import {ISupplierAddress} from "types/ordercloud/ISupplierAddress"
 
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Edit supplier address",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const SupplierAddressListItem = () => {
   const router = useRouter()
   const [supplierAddress, setSupplierAddress] = useState({} as Address)

--- a/src/pages/suppliers/[supplierid]/addresses/index.tsx
+++ b/src/pages/suppliers/[supplierid]/addresses/index.tsx
@@ -1,27 +1,6 @@
-//import {useRouter} from "hooks/useRouter"
-//import SupplierUserGroupList from "@/components/supplierusergroups/list/SupplierUserGroupList"
 import SupplierAddressList from "@/components/supplieraddresses/list/SupplierAddressList"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Supplier Addresses List",
-        metas: {
-          hasBreadcrumbs: true,
-          hasSupplierContextSwitch: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const AddressList = () => {
-  //const router = useRouter()
-  //const supplierID = router.query.supplierid as string
-
   return <SupplierAddressList />
 }
 

--- a/src/pages/suppliers/[supplierid]/addresses/new.tsx
+++ b/src/pages/suppliers/[supplierid]/addresses/new.tsx
@@ -2,21 +2,6 @@ import {SupplierAddressForm} from "@/components/supplieraddresses/SupplierAddres
 import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Create a new supplier address",
-        metas: {
-          hasBreadcrumbs: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 function ProtectedNewSupplierAddressPage() {
   return (
     <ProtectedContent hasAccess={appPermissions.SupplierManager}>

--- a/src/pages/suppliers/[supplierid]/index.tsx
+++ b/src/pages/suppliers/[supplierid]/index.tsx
@@ -7,24 +7,6 @@ import {appPermissions} from "config/app-permissions.config"
 import {useRouter} from "hooks/useRouter"
 import {ISupplier} from "types/ordercloud/ISupplier"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-/* TODO Ask if this is the way to go or better to have getStaticProps + GetStaticPath in this case */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Edit supplier",
-        metas: {
-          hasBreadcrumbs: true,
-          hasBuyerContextSwitch: false,
-          hasSupplierContextSwitch: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const SupplierListItem = () => {
   const router = useRouter()
   const [supplier, setSupplier] = useState({} as Supplier)

--- a/src/pages/suppliers/[supplierid]/usergroups/[usergroupid].tsx
+++ b/src/pages/suppliers/[supplierid]/usergroups/[usergroupid].tsx
@@ -1,27 +1,11 @@
 import {useEffect, useState} from "react"
 import {UserGroupFormForm} from "../../../../components/usergroups/UserGroupForm"
-import {Box, Container, Skeleton} from "@chakra-ui/react"
+import {Container, Skeleton} from "@chakra-ui/react"
 import ProtectedContent from "components/auth/ProtectedContent"
 import {SupplierUserGroups, UserGroup} from "ordercloud-javascript-sdk"
 import {appPermissions} from "config/app-permissions.config"
 import {useRouter} from "hooks/useRouter"
 import {ISupplierUserGroup} from "types/ordercloud/ISupplierUserGroup"
-
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Edit user group",
-        metas: {
-          hasBreadcrumbs: true,
-          hasSupplierContextSwitch: false
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
 
 const UserGroupListItem = () => {
   const router = useRouter()

--- a/src/pages/suppliers/[supplierid]/usergroups/index.tsx
+++ b/src/pages/suppliers/[supplierid]/usergroups/index.tsx
@@ -1,22 +1,6 @@
 import {useRouter} from "hooks/useRouter"
 import SupplierUserGroupList from "@/components/supplierusergroups/list/SupplierUserGroupList"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "User groups List",
-        metas: {
-          hasBreadcrumbs: true,
-          hasSupplierContextSwitch: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const UserGroupsList = () => {
   const router = useRouter()
   const supplierID = router.query.supplierid as string

--- a/src/pages/suppliers/[supplierid]/usergroups/new.tsx
+++ b/src/pages/suppliers/[supplierid]/usergroups/new.tsx
@@ -1,24 +1,7 @@
 import {UserGroupFormForm} from "../../../../components/usergroups"
-import {Box} from "@chakra-ui/react"
 import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 import {SupplierUserGroups} from "ordercloud-javascript-sdk"
-
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Create a new user group",
-        metas: {
-          hasBreadcrumbs: true,
-          hasSupplierContextSwitch: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
 
 const ProtectedSupplierUserGroupPage = () => {
   return (

--- a/src/pages/suppliers/[supplierid]/users/[userid].tsx
+++ b/src/pages/suppliers/[supplierid]/users/[userid].tsx
@@ -7,22 +7,6 @@ import {appPermissions} from "config/app-permissions.config"
 import {useRouter} from "hooks/useRouter"
 import {ISupplierUser} from "types/ordercloud/ISupplierUser"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Update user",
-        metas: {
-          hasBreadcrumbs: true,
-          hasSupplierContextSwitch: false
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const UserListItem = () => {
   const router = useRouter()
   const [user, setUser] = useState({} as User)

--- a/src/pages/suppliers/[supplierid]/users/index.tsx
+++ b/src/pages/suppliers/[supplierid]/users/index.tsx
@@ -2,22 +2,6 @@ import React from "react"
 import {useRouter} from "hooks/useRouter"
 import SupplierUserList from "@/components/supplierusers/list/SupplierUserList"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Users List",
-        metas: {
-          hasBreadcrumbs: true,
-          hasSupplierContextSwitch: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const UsersList = () => {
   const router = useRouter()
   const supplierID = router.query.supplierid as string

--- a/src/pages/suppliers/[supplierid]/users/new.tsx
+++ b/src/pages/suppliers/[supplierid]/users/new.tsx
@@ -3,22 +3,6 @@ import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 import {SupplierUsers} from "ordercloud-javascript-sdk"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getServerSideProps() {
-  return {
-    props: {
-      header: {
-        title: "Create a new user",
-        metas: {
-          hasBreadcrumbs: true,
-          hasSupplierContextSwitch: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const ProtectedNewSupplierUser = () => {
   return (
     <ProtectedContent hasAccess={appPermissions.SupplierManager}>

--- a/src/pages/suppliers/index.tsx
+++ b/src/pages/suppliers/index.tsx
@@ -3,21 +3,6 @@ import React from "react"
 import {appPermissions} from "config/app-permissions.config"
 import SupplierList from "@/components/suppliers/list/SupplierList"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getStaticProps() {
-  return {
-    props: {
-      header: {
-        title: "Suppliers List",
-        metas: {
-          hasBreadcrumbs: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 const ProtectedSuppliersList = () => {
   return (
     <ProtectedContent hasAccess={appPermissions.SupplierManager}>

--- a/src/pages/suppliers/new.tsx
+++ b/src/pages/suppliers/new.tsx
@@ -2,21 +2,6 @@ import {SupplierForm} from "../../components/suppliers/SupplierForm"
 import ProtectedContent from "components/auth/ProtectedContent"
 import {appPermissions} from "config/app-permissions.config"
 
-/* This declare the page title and enable the breadcrumbs in the content header section. */
-export async function getStaticProps() {
-  return {
-    props: {
-      header: {
-        title: "Create a new supplier",
-        metas: {
-          hasBreadcrumbs: true
-        }
-      },
-      revalidate: 5 * 60
-    }
-  }
-}
-
 function ProtectedNewSupplierPage() {
   return (
     <ProtectedContent hasAccess={appPermissions.SupplierManager}>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,8 +29,7 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    "src",
-    "commitlint.config.js"
+    "src"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
While this is built with NextJS, we aren't currently using any server rendered functionality and some partners may prefer to consume this as a static site to ease deployment complexity/cost. 

This pull request makes it easier to do that by removing getServerSideProps and getStaticProps. These parameters were driving breadcrumb, buyer context switcher, and supplier context switcher. They work in the same way they did previously, except instead of getting that information at server time, we are getting it on the client. 

After this PR, partners will be able to run the following commands to build a static site:
1. Run `npm run build`
2. Run `npm run export`
3. Serve the contents in the `/out` folder

The other benefit this PR has, is that it fixes the loading indicator issue in #190 this was being caused by the slight lag required by the server to determine the server side props before rendering the client (with loading state)