### PR TITLE
Update dashboard to pull in real ordercloud data if configured to do so

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ocsellerapp",
+  "name": "ordercloud-react-admin",
   "version": "1.0.0-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "ocsellerapp",
+      "name": "ordercloud-react-admin",
       "version": "1.0.0-alpha.2",
       "dependencies": {
         "@chakra-ui/icons": "^2.0.4",
@@ -26,6 +26,7 @@
         "ordercloud-javascript-sdk": "^5.1.0",
         "overlayscrollbars": "^2.3.0",
         "overlayscrollbars-react": "^0.5.2",
+        "p-limit": "^5.0.0",
         "react": "^18.2.0",
         "react-apexcharts": "^1.4.0",
         "react-datepicker": "^4.8.0",
@@ -7303,6 +7304,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/jest-changed-files/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/jest-circus": {
       "version": "29.5.0",
       "dev": true,
@@ -7344,6 +7372,21 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/jest-circus/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/jest-circus/node_modules/pretty-format": {
       "version": "29.5.0",
       "dev": true,
@@ -7361,6 +7404,18 @@
       "version": "18.2.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jest-circus/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/jest-cli": {
       "version": "29.5.0",
@@ -7939,6 +7994,33 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-runner/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-runtime": {
@@ -9122,14 +9204,14 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
       "dependencies": {
-        "yocto-queue": "^0.1.0"
+        "yocto-queue": "^1.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9142,6 +9224,33 @@
       "dependencies": {
         "p-limit": "^3.0.2"
       },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -11648,11 +11757,11 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -16438,6 +16547,21 @@
           "requires": {
             "path-key": "^3.0.0"
           }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "yocto-queue": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+          "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+          "dev": true
         }
       }
     },
@@ -16471,6 +16595,15 @@
           "version": "5.2.0",
           "dev": true
         },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
         "pretty-format": {
           "version": "29.5.0",
           "dev": true,
@@ -16482,6 +16615,12 @@
         },
         "react-is": {
           "version": "18.2.0",
+          "dev": true
+        },
+        "yocto-queue": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+          "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
           "dev": true
         }
       }
@@ -16866,6 +17005,23 @@
         "jest-worker": "^29.5.0",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "yocto-queue": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+          "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+          "dev": true
+        }
       }
     },
     "jest-runtime": {
@@ -17626,10 +17782,11 @@
       "requires": {}
     },
     "p-limit": {
-      "version": "3.1.0",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
       "requires": {
-        "yocto-queue": "^0.1.0"
+        "yocto-queue": "^1.0.0"
       }
     },
     "p-locate": {
@@ -17637,6 +17794,23 @@
       "dev": true,
       "requires": {
         "p-limit": "^3.0.2"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "yocto-queue": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+          "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+          "dev": true
+        }
       }
     },
     "p-try": {
@@ -19204,8 +19378,9 @@
       "dev": true
     },
     "yocto-queue": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g=="
     },
     "yup": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ordercloud-javascript-sdk": "^5.1.0",
     "overlayscrollbars": "^2.3.0",
     "overlayscrollbars-react": "^0.5.2",
+    "p-limit": "^5.0.0",
     "react": "^18.2.0",
     "react-apexcharts": "^1.4.0",
     "react-datepicker": "^4.8.0",

--- a/src/components/analytics/AverageOrderAmount.tsx
+++ b/src/components/analytics/AverageOrderAmount.tsx
@@ -1,69 +1,18 @@
-import {
-  Flex,
-  Card,
-  Text,
-  Box,
-  useColorModeValue,
-  CardBody,
-  CardHeader,
-  Heading,
-  theme,
-  Icon,
-  Accordion,
-  AccordionItem,
-  AccordionButton,
-  AccordionIcon,
-  AccordionPanel,
-  useDisclosure,
-  Collapse,
-  Button,
-  IconButton
-} from "@chakra-ui/react"
-import React, {useEffect, useState} from "react"
+import {Card, Text, useColorModeValue, CardBody, CardHeader, Heading} from "@chakra-ui/react"
+import React from "react"
 import LineChart from "../charts/LineChart"
-import {dashboardService} from "services/dashboard.service"
 import schraTheme from "theme/theme"
-import {
-  TbArrowBackUp,
-  TbCaretUp,
-  TbChevronUp,
-  TbCircleCaretUp,
-  TbSquareChevronUp,
-  TbSquareRoundedChevronUpFilled,
-  TbTriangle,
-  TbTriangleFilled
-} from "react-icons/tb"
-import {ChevronDownIcon, ChevronUpIcon, TriangleUpIcon} from "@chakra-ui/icons"
-import {appSettings} from "config/app-settings"
+import {TriangleUpIcon} from "@chakra-ui/icons"
+const chartData = require("../../mockdata/dashboard_data.json")
+
+// Note: This is a mock component. It is not hooked up to any data.
+// If you want to implement this with real data it is HIGHLY recommended that you
+// aggregate and cache data on some interval (daily) instead of retrieving it client-side every time
 
 export default function AverageOrderAmount() {
   const headingColor = useColorModeValue("boxTextColor.400", "boxTextColor.300")
   const labelColor = useColorModeValue("blackAlpha.400", "whiteAlpha.500")
-  const [totalSales, settotalSales] = useState([Number])
-  const [totalPreviousYearSales, settotalPreviousYearSales] = useState([Number])
-  const graphColor1 = useColorModeValue(schraTheme.colors.primary[500], schraTheme.colors.primary[300])
-  const graphColor2 = useColorModeValue(schraTheme.colors.accent[500], schraTheme.colors.accent[300])
-  //const [chartData, setchartData] = useState()
-  let chartData = require("../../mockdata/dashboard_data.json")
-  useEffect(() => {
-    initData()
-  }, [])
 
-  async function initData() {
-    if (appSettings.useRealDashboardData === "true") {
-      //TODO COMPLETE THIS SECTION
-      //These functions will bring in real data
-      //const totalSales = await dashboardService.getTotalSalesByMonth()
-      //settotalSales(totalSales)
-      //const totalSalesPreviousYear =
-      // await dashboardService.getTotalSalesPreviousYearByMonth()
-      //settotalPreviousYearSales(totalSalesPreviousYear)
-    } else {
-      //This function will bring in mock data
-      //let data = require("../../mockdata/dashboard_data.json")
-      //setchartData(data)
-    }
-  }
   const d = new Date()
   let year = d.getFullYear()
   const options = {

--- a/src/components/analytics/PercentChangeTile.tsx
+++ b/src/components/analytics/PercentChangeTile.tsx
@@ -1,28 +1,32 @@
 import {TriangleDownIcon, TriangleUpIcon} from "@chakra-ui/icons"
-import {
-  Flex,
-  Card,
-  Text,
-  Box,
-  Icon,
-  useColorModeValue,
-  CardHeader,
-  CardBody,
-  Heading,
-  IconButton
-} from "@chakra-ui/react"
+import {Card, Text, useColorModeValue, CardBody, Heading} from "@chakra-ui/react"
 import React from "react"
-import {TbArrowsDiagonal, TbArrowsDiagonal2, TbLayoutNavbarExpand, TbLayoutSidebarLeftExpand} from "react-icons/tb"
-import schraTheme from "theme/theme"
+import {priceHelper} from "utils"
 
-export default function PercentChangeTitle(prop) {
+interface PercentChangeTileProps {
+  previousAmount: number
+  currentAmount: number
+  title: string
+  label: string
+  icon: any
+  isMoney?: boolean
+}
+export default function PercentChangeTile({
+  previousAmount,
+  currentAmount,
+  title,
+  label,
+  isMoney = true
+}: PercentChangeTileProps) {
   const color = useColorModeValue("blackAlpha.500", "whiteAlpha.500")
   const labelColor = useColorModeValue("blackAlpha.400", "whiteAlpha.500")
   const borderColorPos = useColorModeValue("green.300", "green.700")
   const borderColorNeg = useColorModeValue("red.100", "red.800")
+  const percentchange = Math.round(((currentAmount - previousAmount) / previousAmount) * 100)
+  const percentchangetype = percentchange > 0 ? "pos" : "neg"
 
   return (
-    <Card w="full" border=".5px solid" borderColor={prop.percentchangetype === "pos" ? borderColorPos : borderColorNeg}>
+    <Card w="full" border=".5px solid" borderColor={percentchangetype === "pos" ? borderColorPos : borderColorNeg}>
       <CardBody display="flex" flexFlow="column nowrap" pos={"relative"}>
         <Text
           fontSize="5xl"
@@ -32,10 +36,10 @@ export default function PercentChangeTitle(prop) {
           display="inline-flex"
           alignItems="center"
         >
-          {prop.totalamount}
+          {isMoney ? priceHelper.formatShortPrice(currentAmount) : currentAmount}
         </Text>
-        <Heading fontSize="lg" mb="6px" textTransform="capitalize" mt={"auto"}>
-          {prop.title}
+        <Heading fontSize="lg" mb="6px" mt={"auto"}>
+          {title}
         </Heading>
         <Text
           as="span"
@@ -47,19 +51,18 @@ export default function PercentChangeTitle(prop) {
           alignItems="center"
           gap={1}
         >
-          {prop.percentchangetype === "pos" ? (
+          {percentchangetype === "pos" ? (
             <Text as="span" color="green.400" fontWeight="bold" display="inline-flex" alignItems="center" gap={1}>
-              <TriangleUpIcon /> {prop.percentchange}%
+              <TriangleUpIcon /> {percentchange}%
             </Text>
           ) : (
             <Text as="span" color="red.400" fontWeight="bold" display="inline-flex" alignItems="center" gap={1}>
               <TriangleDownIcon />
-              {prop.percentchange}%
+              {percentchange}%
             </Text>
           )}{" "}
-          {prop.percentlabel}
+          {label}
         </Text>
-        {/* {prop.icon} */}
       </CardBody>
     </Card>
   )

--- a/src/mockdata/dashboard_data.json
+++ b/src/mockdata/dashboard_data.json
@@ -15,24 +15,26 @@
       }
     }
   },
+  "uniqueusers": {
+    "totalamount": 53,
+    "previoustotalamount": 40
+  },
   "todaysmoney": {
-    "title": "Todays Money",
     "totalamount": 2500,
     "previoustotalamount": 1100
   },
-  "totalsales": {
-    "title": "Total Sales",
+  "weeksales": {
     "totalamount": 5500,
     "previoustotalamount": 1400
   },
   "newusers": {
-    "title": "New Users",
-    "totalamount": 231,
+    "totalamount": 24,
     "previoustotalamount": 170
   },
-  "totalusers": {
-    "title": "Total Users",
-    "totalamount": 25000,
-    "previoustotalamount": 12000
+  "totalpromos": {
+    "totalamount": 15
+  },
+  "totalproducts": {
+    "totalamount": 7560
   }
 }

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -4,7 +4,6 @@ import {
   SimpleGrid,
   Text,
   VStack,
-  useColorMode,
   useColorModeValue,
   CardHeader,
   CardBody,
@@ -13,50 +12,43 @@ import {
   Flex,
   useMediaQuery,
   theme,
-  Heading
+  Heading,
+  Skeleton
 } from "@chakra-ui/react"
-import {HiOutlineCurrencyDollar, HiOutlineFolderOpen, HiOutlineUserAdd, HiOutlineUserCircle} from "react-icons/hi"
+import {HiOutlineCurrencyDollar, HiOutlineFolderOpen, HiOutlineUserAdd} from "react-icons/hi"
 import {useEffect, useState} from "react"
 import AverageOrderAmount from "components/analytics/AverageOrderAmount"
-import NewClients from "components/analytics/PercentChangeTile"
 import {NextSeo} from "next-seo"
-import TodaysMoney from "components/analytics/PercentChangeTile"
-import TodaysUsers from "components/analytics/PercentChangeTile"
-import TotalSales from "components/analytics/PercentChangeTile"
+import PercentChangeTile from "components/analytics/PercentChangeTile"
 import {appPermissions} from "config/app-permissions.config"
-import {priceHelper} from "utils/price.utils"
 import useHasAccess from "hooks/useHasAccess"
 import {Link} from "components/navigation/Link"
-import {Orders, Products, Promotions} from "ordercloud-javascript-sdk"
+import {ListPage} from "ordercloud-javascript-sdk"
 import {IOrder} from "types/ordercloud/IOrder"
-import {IProduct} from "types/ordercloud/IProduct"
-import {IPromotion} from "types/ordercloud/IPromotion"
 import {dashboardService} from "services/dashboard.service"
 import schraTheme from "theme/theme"
 import {TbArrowsDiagonal} from "react-icons/tb"
+import {appSettings} from "config/app-settings"
+import {dateHelper} from "utils"
+
+interface DashboardData {
+  todaysSales?: number
+  previousTodaysSales?: number
+  weekSales?: number
+  previousWeekSales?: number
+  weekUniqueUsers?: number
+  previousWeekUniqueUsers?: number
+  ordersList?: ListPage<IOrder>
+  totalProductsCount?: number
+  totalPromosCount?: number
+}
 
 const Dashboard = () => {
-  const {colorMode, toggleColorMode} = useColorMode()
-  const [orders, setOrders] = useState([])
-  const [products, setProducts] = useState([])
-  const [promotions, setPromotions] = useState([])
-  const [users, setUsers] = useState([])
-
-  const [totalTodaysSales, settotalTodaysSales] = useState(Number)
-  const [previousTodaysSales, setpreviousTodaysSales] = useState(Number)
-  const [percentTodaysSalesChange, setpercentTodaysSalesChange] = useState(String)
-  const [totalSales, settotalSales] = useState(Number)
-  const [percentSales, setpercentSales] = useState(Number)
-  const [percentSalesChange, setpercentSalesChange] = useState(String)
-  const [totalUsers, settotalUsers] = useState(Number)
-  const [percentTotalUsers, setpercentTotalUsers] = useState(Number)
-  const [percentTotalUsersChange, setpercentTotalUsersChange] = useState(String)
-  const [totalNewUsers, settotalNewUsers] = useState(Number)
-  const [percentNewUsers, setpercentNewUsers] = useState(Number)
-  const [percentNewUsersChange, setpercentNewUsersChange] = useState(String)
-  const [canViewReports, setCanViewReports] = useState(false)
+  const color = useColorModeValue("blackAlpha.500", "whiteAlpha.500")
+  const labelColor = useColorModeValue("blackAlpha.400", "whiteAlpha.500")
   const hasAccessToViewReports = useHasAccess(appPermissions.DashboardViewer)
-  const [dashboardListMeta, setDashboardMeta] = useState({})
+  const [canViewReports, setCanViewReports] = useState(false)
+  const [data, setData] = useState<DashboardData>({})
 
   const [above2xl] = useMediaQuery(`(min-width: ${theme.breakpoints["2xl"]})`, {
     ssr: true,
@@ -68,122 +60,90 @@ const Dashboard = () => {
   }, [hasAccessToViewReports])
 
   useEffect(() => {
+    const initDashboardData = async () => {
+      const [ordersList, totalProductsCount, totalPromosCount] = await Promise.all([
+        dashboardService.listAllOrdersSincePreviousWeek(),
+        dashboardService.getTotalProductsCount(),
+        dashboardService.getTotalPromosCount()
+      ])
+
+      // Todays Sales
+      const todaysSales = dashboardService.getTodaysMoney(ordersList.Items)
+      const previousTodaysSales = dashboardService.getPreviousTodaysMoney(ordersList.Items)
+
+      // Total Sales
+      const weekSales = dashboardService.getWeeklySales(ordersList.Items)
+      const previousWeekSales = dashboardService.getPreviousWeeklySales(ordersList.Items)
+
+      // Unique Users
+      const weekUniqueUsers = dashboardService.getWeekUniqueUsers(ordersList.Items)
+      const previousWeekUniqueUsers = dashboardService.getPreviousWeekUniqueUsers(ordersList.Items)
+
+      setData({
+        todaysSales,
+        previousTodaysSales,
+        weekSales,
+        previousWeekSales,
+        weekUniqueUsers,
+        previousWeekUniqueUsers,
+        ordersList,
+        totalProductsCount,
+        totalPromosCount
+      })
+    }
     if (!canViewReports) {
       return
     }
     initDashboardData()
   }, [canViewReports])
 
-  async function initDashboardData() {
-    let _dashboardListMeta = {}
-    const ordersList = await Orders.List<IOrder>("All")
-    const productsList = await Products.List<IProduct>()
-    const promotionsList = await Promotions.List<IPromotion>()
-    const usersList = await Promotions.List<IPromotion>()
-    //Todays Sales
-    const todaysSales = await dashboardService.getTodaysMoney()
-    settotalTodaysSales(todaysSales)
-    const previousTodaysSales = await dashboardService.getPreviousTodaysMoney()
-    const percentChange = ((todaysSales - previousTodaysSales) / todaysSales) * 100.0
-    setpreviousTodaysSales(Math.round(percentChange))
-
-    let percentChangeToday = "pos"
-    if (todaysSales < previousTodaysSales) {
-      percentChangeToday = "neg"
-    }
-    setpercentTodaysSalesChange(percentChangeToday)
-
-    //Total Sales
-    const totalSales = await dashboardService.getTotalSales()
-    settotalSales(totalSales)
-
-    const previousTotalSales = await dashboardService.getPreviousTotalSales()
-    const percentChangeTotalSales = ((totalSales - previousTotalSales) / totalSales) * 100.0
-    setpercentSales(Math.round(percentChangeTotalSales))
-
-    let percentChangeTotal = "pos"
-    if (totalSales < previousTotalSales) {
-      percentChangeTotal = "neg"
-    }
-    setpercentSalesChange(percentChangeTotal)
-
-    //Total Users
-    const totalUsers = await dashboardService.getTotalUsers()
-    settotalUsers(totalUsers.toLocaleString("en-US"))
-
-    const previousTotalUsers = await dashboardService.getPreviousTotalUsers()
-    const percentChangeTotalUsers = ((totalUsers - previousTotalUsers) / totalUsers) * 100.0
-    setpercentTotalUsers(Math.round(percentChangeTotalUsers))
-
-    let percentChangeUsers = "pos"
-    if (totalUsers < previousTotalUsers) {
-      percentChangeUsers = "neg"
-    }
-    setpercentTotalUsersChange(percentChangeUsers)
-
-    //Total New Users
-    const totalNewUsers = await dashboardService.getTotalNewUsers()
-    settotalNewUsers(totalNewUsers.toLocaleString("en-US"))
-
-    const previousTotalNewUsers = await dashboardService.getPreviousTotalNewUsers()
-    const percentChangeTotalNewUsers = ((totalNewUsers - previousTotalNewUsers) / totalNewUsers) * 100.0
-    setpercentNewUsers(Math.round(percentChangeTotalNewUsers))
-
-    let percentChangeNewUsers = "pos"
-    if (totalNewUsers < previousTotalNewUsers) {
-      percentChangeNewUsers = "neg"
-    }
-    setpercentNewUsersChange(percentChangeNewUsers)
-
-    setDashboardMeta(_dashboardListMeta)
-    //setBuyers(buyersList.Items)
-    setOrders(ordersList.Items)
-    setProducts(productsList.Items)
-    setPromotions(promotionsList.Items)
-    setUsers(usersList.Items)
-  }
-
-  const gradient =
-    colorMode === "light" ? "linear(to-t, accent.300, accent.400)" : "linear(to-t, accent.600, accent.500)"
-  const color = useColorModeValue("blackAlpha.500", "whiteAlpha.500")
-  const labelColor = useColorModeValue("blackAlpha.400", "whiteAlpha.500")
-
-  // TODO: build skeleton for this
   if (!canViewReports) {
     return <div></div>
   }
 
-  const productsLatestUpdated = new Date(
-    (products || [])
-      .filter((p) => p.Inventory !== null)
-      .map((i) => i?.Inventory)
-      .map((lu) => lu?.LastUpdated)
-      .reduce((a, b) => (a.MeasureDate > b.MeasureDate ? a : b), {})
-  ).toLocaleDateString()
-  const ordersLatestUpdated = new Date(
-    orders?.map((lu) => lu?.LastUpdated)?.reduce((a, b) => (a.MeasureDate > b.MeasureDate ? a : b), {})
-  ).toLocaleDateString()
-  const usersLatestUpdated = new Date(
-    users
-      ?.map((i) => i?.StartDate)
-      ?.filter((wtf) => wtf)
-      ?.reduce((a, b) => (a.MeasureDate > b.MeasureDate ? a : b), {})
-  ).toLocaleDateString()
-  const promotionsLatestUpdated = new Date(
-    promotions
-      ?.map((i) => i?.StartDate)
-      ?.filter((wtf) => wtf)
-      ?.reduce((a, b) => (a.MeasureDate > b.MeasureDate ? a : b), {})
-  ).toLocaleDateString()
-
-  const data = [
-    {label: "products", labelSingular: "product", var: products, funFact: productsLatestUpdated},
-    {label: "orders", labelSingular: "order", var: orders, funFact: ordersLatestUpdated},
-    {label: "users", labelSingular: "user", var: users, funFact: usersLatestUpdated},
-    {label: "promotions", labelSingular: "promotion", var: promotions, funFact: promotionsLatestUpdated}
+  const miniWidgetsData = [
+    {
+      label: "total orders",
+      labelSingular: "order",
+      count: data.ordersList?.Meta?.TotalCount,
+      lastUpdated: dateHelper.formatDate(
+        data.ordersList?.Items?.length ? data.ordersList.Items[0].LastUpdated : new Date().toISOString()
+      )
+    },
+    {label: "total products", labelSingular: "product", count: data.totalProductsCount},
+    {
+      label: "total promotions",
+      labelSingular: "promotion",
+      count: data.totalPromosCount
+    }
   ]
 
-  const miniWidgets = data.map((item) => (
+  const percentChangeTileData = [
+    {
+      title: "Today's Money",
+      label: "Compared to yesterday",
+      currentAmount: data.todaysSales,
+      previousAmount: data.previousTodaysSales,
+      icon: <Icon as={HiOutlineFolderOpen} />
+    },
+    {
+      title: "Week Sales",
+      label: "Compared to last week (wtd)",
+      currentAmount: data.weekSales,
+      previousAmount: data.previousWeekSales,
+      icon: <Icon as={HiOutlineCurrencyDollar} />
+    },
+    {
+      title: "Unique weekly users",
+      label: "Compared to last week (wtd)",
+      currentAmount: data.weekUniqueUsers,
+      previousAmount: data.previousWeekUniqueUsers,
+      icon: <Icon as={HiOutlineUserAdd} />,
+      isMoney: false
+    }
+  ]
+
+  const miniWidgets = miniWidgetsData.map((item) => (
     <Card
       as={Link}
       variant={"levitating"}
@@ -202,9 +162,9 @@ const Dashboard = () => {
         top={2}
       />
       <CardHeader py={0}>
-        {item.var != null ? (
+        {item.count ? (
           <Text fontWeight={"light"} color={color} fontSize="5xl">
-            {item.var.length}
+            {item.count}
           </Text>
         ) : (
           <Spinner mt={4} />
@@ -214,16 +174,50 @@ const Dashboard = () => {
         <Heading fontSize="lg" mb="6px" textTransform="capitalize" mt={"auto"}>
           {item.label}
         </Heading>
-        <Text fontSize="xs" fontWeight="normal" color={labelColor} casing="uppercase">
-          latest {item.label.toString()} update:
-          <Text as={"span"} fontSize="xs" fontWeight={"semibold"}>
-            {" "}
-            {item.funFact}
+        {item.lastUpdated && (
+          <Text fontSize="xs" fontWeight="normal" color={labelColor} casing="uppercase">
+            latest {item.label.toString()} update:
+            <Text as={"span"} fontSize="xs" fontWeight={"semibold"}>
+              {" "}
+              {item.lastUpdated}
+            </Text>
           </Text>
-        </Text>
+        )}
       </CardBody>
     </Card>
   ))
+
+  if (typeof data.todaysSales === "undefined") {
+    return (
+      <>
+        <NextSeo title="Dashboard" />
+        <VStack flexGrow={1} gap={4} p={[4, 6, 8]} h="100%" w="100%" bg={"st.mainBackgroundColor"}>
+          <Flex w="100%" gap={4} direction={above2xl ? "row" : "column-reverse"}>
+            <SimpleGrid
+              w="100%"
+              gap={4}
+              templateRows={above2xl && "1fr 1fr"}
+              templateColumns={{
+                md: "1fr 1fr",
+                xl: "repeat(auto-fit, minmax(48%, 1fr))"
+              }}
+            >
+              {percentChangeTileData.map((_item, index) => {
+                return <Skeleton key={index} borderRadius="md" w="100%" h="171px" />
+              })}
+            </SimpleGrid>
+            {!appSettings.useRealDashboardData && <AverageOrderAmount />}
+          </Flex>
+
+          <SimpleGrid w="full" spacing={4} templateColumns="repeat(auto-fit, minmax(200px, 1fr))">
+            {miniWidgetsData.map((_item, index) => {
+              return <Skeleton key={index} borderRadius="md" w="100%" h="138px" />
+            })}
+          </SimpleGrid>
+        </VStack>
+      </>
+    )
+  }
 
   return (
     <>
@@ -239,43 +233,21 @@ const Dashboard = () => {
               xl: "repeat(auto-fit, minmax(48%, 1fr))"
             }}
           >
-            <TodaysMoney
-              title="todays money"
-              totalamount={` ${priceHelper.formatShortPrice(totalTodaysSales)} `}
-              percentchange={previousTodaysSales}
-              percentchangetype={percentTodaysSalesChange}
-              percentlabel="Compared to last month (mtd)"
-              icon={<Icon as={HiOutlineFolderOpen} />}
-            />
-
-            <TotalSales
-              title="total sales"
-              totalamount={` ${priceHelper.formatShortPrice(totalSales)} `}
-              percentchange={percentSales}
-              percentchangetype={percentSalesChange}
-              percentlabel="Compared to last year  (ytd)"
-              icon={<Icon as={HiOutlineCurrencyDollar} />}
-            />
-
-            <NewClients
-              title="new users"
-              totalamount={totalNewUsers}
-              percentchange={percentNewUsers}
-              percentchangetype={percentNewUsersChange}
-              percentlabel="Compared to last month (mtd)"
-              icon={<Icon as={HiOutlineUserAdd} />}
-            />
-
-            <TodaysUsers
-              title="total users"
-              totalamount={totalUsers}
-              percentchange={percentTotalUsers}
-              percentchangetype={percentTotalUsersChange}
-              percentlabel="Compared to last year  (ytd)"
-              icon={<Icon as={HiOutlineUserCircle} />}
-            />
+            {percentChangeTileData.map((item) => {
+              return (
+                <PercentChangeTile
+                  key={item.title}
+                  title={item.title}
+                  label={item.label}
+                  currentAmount={item.currentAmount}
+                  previousAmount={item.previousAmount}
+                  icon={item.icon}
+                  isMoney={item.isMoney}
+                />
+              )
+            })}
           </SimpleGrid>
-          <AverageOrderAmount />
+          {!appSettings.useRealDashboardData && <AverageOrderAmount />}
         </Flex>
 
         <SimpleGrid w="full" spacing={4} templateColumns="repeat(auto-fit, minmax(200px, 1fr))">


### PR DESCRIPTION
If NEXT_PUBLIC_USE_REAL_DASHBOARD_DATA is set to true then the dashboard will show real OrderCloud data.

Note that the graph is not possible to implement without a backend component due to the sheer amount of API calls that would be required. If this type of analytics is required its recommended to compound that data on the backend separately and then simply retrieve the results client-side.

The data displayed has been modified slightly as well. Instead of monthly intervals we are showing weekly