### PR TITLE
Found an issue when saving any kind of address, where the ID of the a…

### DIFF
--- a/src/components/addresses/AddressForm.tsx
+++ b/src/components/addresses/AddressForm.tsx
@@ -122,7 +122,7 @@ export function AddressForm({address, addressType, parentId, onCreate, onUpdate,
   }
 
   async function updateAddress(fields: IAdminAddress) {
-    const diff = getObjectDiff(currentAddress, fields)
+    const diff = getObjectDiff(currentAddress, fields, ["ID"])
     const updatedAddress = await updateOrderCloudAddress(diff)
     if (onUpdate) {
       await onUpdate(updatedAddress)

--- a/src/utils/object.utils.ts
+++ b/src/utils/object.utils.ts
@@ -5,8 +5,9 @@ import {get, isArray, isEqual, isObject, set} from "lodash"
  *
  * @param oldObj The original object to be compared
  * @param newObj The new object with updates
+ * @param alwaysIncludeField An optional Array of field names that always get included even if the values are the same
  */
-export function getObjectDiff(oldObj = {}, newObj = {}) {
+export function getObjectDiff(oldObj = {}, newObj = {}, alwaysIncludeField?: string[]) {
   const diff = {}
   const diffKeys = getObjectDiffKeys(oldObj, newObj)
   if (!diffKeys?.length) {
@@ -16,6 +17,12 @@ export function getObjectDiff(oldObj = {}, newObj = {}) {
     const value = get(newObj, diffKey, null)
     set(diff, diffKey, value)
   })
+  if (alwaysIncludeField) {
+    alwaysIncludeField.forEach((keep) => {
+      const value = get(oldObj, keep, null)
+      set(diff, keep, value)
+    })
+  }
   return diff
 }
 


### PR DESCRIPTION
…ddress was removed by the diff function and caused the patch to fail.

Extended the diff function to include an additional optional array of field names, that forces the diff function to always inclulde the listed fields.